### PR TITLE
Warm UX redesign + image fixes

### DIFF
--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -37,6 +37,26 @@ To add more backend features (database, storage, etc.), use Supabase client APIs
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
+### Local development with Azure Functions
+
+The app uses Azure Functions (`api/`) for image handling. During local development, Vite proxies `/api/*` to the Azure Functions runtime on port 7071. Start both in separate terminals:
+
+```bash
+# Terminal 1: Azure Functions
+cd api && func start
+
+# Terminal 2: Vite dev server
+npm run dev
+```
+
+Alternatively, use the [Azure Static Web Apps CLI](https://azure.github.io/static-web-apps-cli/) which starts both together:
+
+```bash
+swa start
+```
+
+Without the Functions runtime running, image uploads and image URL resolution will fail silently and cards will show placeholder icons.
+
 Currently, two official plugins are available:
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
@@ -102,11 +122,11 @@ Setting the form field to empty triggers a patch with `image_id: null`. The hook
 
 ### Caching Model
 
-| Layer | Purpose | Scope |
-|-------|---------|-------|
-| In-memory map (`imageUrls.ts`) | Fast repeat access | Session |
-| In-flight map | Prevent duplicate network calls for same id(s) | Request window |
-| Zustand store `imageUrls` maps | Rehydrate between navigations (lightweight) | Session/localStorage |
+| Layer                          | Purpose                                        | Scope                |
+| ------------------------------ | ---------------------------------------------- | -------------------- |
+| In-memory map (`imageUrls.ts`) | Fast repeat access                             | Session              |
+| In-flight map                  | Prevent duplicate network calls for same id(s) | Request window       |
+| Zustand store `imageUrls` maps | Rehydrate between navigations (lightweight)    | Session/localStorage |
 
 ### Error / Edge Handling
 
@@ -125,7 +145,6 @@ Image logic is tested at multiple layers:
 - Integration: `imageClear.test.tsx` ensures nulling an image propagates correctly.
 
 When extending the image system (e.g., adding drag & drop or alt text editing), prefer adding a new focused test file alongside existing ones.
-
 
 You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,33 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+Individuals and families organizing personal physical storage: garages, attics, basements, moving boxes. They use the app in two modes — calm and methodical when labeling and organizing, stressed and focused when searching for a specific item. Primary device is a phone, often in the physical space being organized (garage, hallway). Sessions are short and task-driven.
+
+## Product Purpose
+
+Storage Manager helps people track what's in their physical boxes and storage spaces. It eliminates the stress of "where did I put that?" by giving a clear, organized digital map of spaces, boxes, and items. QR code labels on boxes are the killer feature: they link the physical world directly to the digital inventory. Success means: finding a stored item in under a minute, and labeling a new box in under two minutes.
+
+## Brand Personality
+
+Simple, playful, approachable. Like a helpful friend who's great at organizing — warm and encouraging, not corporate or clinical. Never overwhelming.
+
+## Anti-references
+
+Enterprise inventory management systems (cluttered, data-dense, grey). Generic SaaS dashboards with too many numbers and competing actions. Cold grid-heavy warehouse tools. Any interface where the user has to hunt for the primary action.
+
+## Design Principles
+
+1. **One obvious next step.** Every screen should make the primary action unmistakable. Remove anything that competes for that attention.
+2. **Warmth earns trust.** The visual language should feel like home, not an office. Cream tones, soft depth, human photography.
+3. **The physical world is primary.** The app exists to serve real boxes in real spaces. Labels, QR codes, and photos are first-class features, not afterthoughts.
+4. **Progressive disclosure.** Power features (bulk operations, sharing, roles) don't crowd the primary task. Owners see more than viewers, but quietly.
+5. **Fast to search, fast to add.** The two core jobs — finding something and logging something — should feel immediate on a phone.
+
+## Accessibility & Inclusion
+
+WCAG AA minimum. Mobile-first layout (most use is on phone in a physical space). Support reduced motion. All interactive elements keyboard-focusable. Images have descriptive alt text; decorative images use empty alt.

--- a/api/RegenerateThumbnails.cs
+++ b/api/RegenerateThumbnails.cs
@@ -1,0 +1,132 @@
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Webp;
+using SixLabors.ImageSharp.Processing;
+
+/// <summary>
+/// One-time admin utility: re-generates thumbnails for all existing images at the
+/// new 480×360 resolution. Safe to call multiple times — it always overwrites.
+///
+/// Usage:
+///   curl -X POST https://{host}/api/admin/regenerate-thumbnails \
+///        -H "X-Admin-Key: {ADMIN_KEY value from app settings}"
+/// </summary>
+public class RegenerateThumbnails(ILogger<RegenerateThumbnails> log)
+{
+    private readonly ILogger<RegenerateThumbnails> log = log;
+
+    [Function("RegenerateThumbnails")]
+    public async Task<IActionResult> Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post",
+            Route = "admin/regenerate-thumbnails")] HttpRequest req)
+    {
+        // Simple shared-secret guard so this can't be triggered by accident.
+        string? expectedKey = Environment.GetEnvironmentVariable("ADMIN_KEY");
+        if (string.IsNullOrEmpty(expectedKey))
+        {
+            log.LogError("ADMIN_KEY env var not set — refusing to run");
+            return new ObjectResult(new { error = "ADMIN_KEY not configured" })
+            { StatusCode = 500 };
+        }
+        string? providedKey = req.Headers["X-Admin-Key"].FirstOrDefault()
+                              ?? req.Query["key"].FirstOrDefault();
+        if (providedKey != expectedKey)
+            return new UnauthorizedObjectResult(new { error = "Invalid or missing X-Admin-Key header" });
+
+        string containerName = Environment.GetEnvironmentVariable("BLOB_CONTAINER_NAME") ?? "images";
+        string? connectionString = Environment.GetEnvironmentVariable("StorageAccountConnectionString");
+        if (string.IsNullOrEmpty(connectionString))
+        {
+            log.LogError("StorageAccountConnectionString not configured");
+            return new ObjectResult(new { error = "server misconfiguration" }) { StatusCode = 500 };
+        }
+
+        var blobServiceClient = new BlobServiceClient(connectionString);
+        var containerClient = blobServiceClient.GetBlobContainerClient(containerName);
+
+        int processed = 0, skipped = 0, failed = 0;
+        var failures = new List<string>();
+
+        var encoder = new WebpEncoder { Quality = 80, Method = WebpEncodingMethod.Default };
+
+        // Enumerate all blobs; filter to originals only.
+        await foreach (var item in containerClient.GetBlobsAsync(
+            traits: BlobTraits.Metadata, prefix: ""))
+        {
+            item.Metadata.TryGetValue("type", out var blobType);
+            if (blobType != "original") { skipped++; continue; }
+
+            // Derive thumbnail blob name from original: {id}/{id}-original.webp -> {id}/{id}-thumbnail.webp
+            string originalName = item.Name;
+            string thumbnailName = originalName.Replace("-original.webp", "-thumbnail.webp",
+                StringComparison.OrdinalIgnoreCase);
+
+            if (thumbnailName == originalName)
+            {
+                // Unexpected name format — skip rather than corrupt data
+                log.LogWarning("Could not derive thumbnail name from {Name}", originalName);
+                skipped++;
+                continue;
+            }
+
+            try
+            {
+                // Download original
+                var originalClient = containerClient.GetBlobClient(originalName);
+                using var download = await originalClient.OpenReadAsync();
+                using var img = await Image.LoadAsync(download);
+
+                // Re-encode thumbnail at 480×360 (4:3 landscape crop)
+                using var thumb = img.Clone(ctx => ctx.Resize(new ResizeOptions
+                {
+                    Size = new Size(480, 360),
+                    Mode = ResizeMode.Crop,
+                }));
+
+                using var ms = new MemoryStream();
+                await thumb.SaveAsync(ms, encoder);
+                ms.Position = 0;
+
+                var thumbClient = containerClient.GetBlobClient(thumbnailName);
+                await thumbClient.UploadAsync(ms, new BlobUploadOptions
+                {
+                    HttpHeaders = new BlobHttpHeaders
+                    {
+                        ContentType = "image/webp",
+                        CacheControl = "public, max-age=31536000",
+                    },
+                    // Preserve existing metadata but ensure type tag is correct
+                    Metadata = new Dictionary<string, string>
+                    {
+                        ["derived_from"] = originalName,
+                        ["type"] = "thumbnail",
+                        ["regenerated"] = DateTimeOffset.UtcNow.ToString("O"),
+                    },
+                });
+
+                log.LogInformation("Regenerated thumbnail for {OriginalName}", originalName);
+                processed++;
+            }
+            catch (Exception ex)
+            {
+                log.LogError(ex, "Failed to regenerate thumbnail for {OriginalName}", originalName);
+                failures.Add(originalName);
+                failed++;
+            }
+        }
+
+        return new OkObjectResult(new
+        {
+            processed,
+            skipped,
+            failed,
+            failures,
+            message = $"Done. {processed} thumbnail(s) regenerated, {skipped} blob(s) skipped, {failed} failed.",
+        });
+    }
+}

--- a/api/RegenerateThumbnails.cs
+++ b/api/RegenerateThumbnails.cs
@@ -33,8 +33,7 @@ public class RegenerateThumbnails(ILogger<RegenerateThumbnails> log)
             return new ObjectResult(new { error = "ADMIN_KEY not configured" })
             { StatusCode = 500 };
         }
-        string? providedKey = req.Headers["X-Admin-Key"].FirstOrDefault()
-                              ?? req.Query["key"].FirstOrDefault();
+        string? providedKey = req.Headers["X-Admin-Key"].FirstOrDefault();
         if (providedKey != expectedKey)
             return new UnauthorizedObjectResult(new { error = "Invalid or missing X-Admin-Key header" });
 
@@ -93,6 +92,26 @@ public class RegenerateThumbnails(ILogger<RegenerateThumbnails> log)
                 ms.Position = 0;
 
                 var thumbClient = containerClient.GetBlobClient(thumbnailName);
+
+                // Fetch existing thumbnail metadata so we preserve keys set by ConfirmImage
+                // (e.g. status=confirmed, space_id, box_id). Merge with our fixed keys.
+                var mergedMeta = new Dictionary<string, string>
+                {
+                    ["derived_from"] = originalName,
+                    ["type"] = "thumbnail",
+                    ["regenerated"] = DateTimeOffset.UtcNow.ToString("O"),
+                };
+                if (await thumbClient.ExistsAsync())
+                {
+                    var props = await thumbClient.GetPropertiesAsync();
+                    foreach (var kv in props.Value.Metadata)
+                        mergedMeta.TryAdd(kv.Key, kv.Value); // existing keys win for unknown fields
+                    // Ensure our controlled keys always reflect current truth
+                    mergedMeta["derived_from"] = originalName;
+                    mergedMeta["type"] = "thumbnail";
+                    mergedMeta["regenerated"] = DateTimeOffset.UtcNow.ToString("O");
+                }
+
                 await thumbClient.UploadAsync(ms, new BlobUploadOptions
                 {
                     HttpHeaders = new BlobHttpHeaders
@@ -100,13 +119,7 @@ public class RegenerateThumbnails(ILogger<RegenerateThumbnails> log)
                         ContentType = "image/webp",
                         CacheControl = "public, max-age=31536000",
                     },
-                    // Preserve existing metadata but ensure type tag is correct
-                    Metadata = new Dictionary<string, string>
-                    {
-                        ["derived_from"] = originalName,
-                        ["type"] = "thumbnail",
-                        ["regenerated"] = DateTimeOffset.UtcNow.ToString("O"),
-                    },
+                    Metadata = mergedMeta,
                 });
 
                 log.LogInformation("Regenerated thumbnail for {OriginalName}", originalName);

--- a/api/UploadImage.cs
+++ b/api/UploadImage.cs
@@ -98,12 +98,13 @@ public class UploadImage(ILogger<UploadImage> log)
 
             log.LogInformation("Uploaded original (converted WebP) image {OriginalBlob}", originalBlobName);
 
-            // Create thumbnail (square crop) then encode as WebP
-            const int thumbSize = 150;
+            // Create thumbnail (4:3 landscape crop) then encode as WebP.
+            // 480×360 covers a 4-column card grid on a 1440px screen at 1× and a
+            // 2-column grid on a 375px mobile at 2× (Retina), without being wasteful.
             using var thumbnailImage = image.Clone(ctx =>
                 ctx.Resize(new ResizeOptions
                 {
-                    Size = new Size(thumbSize, thumbSize),
+                    Size = new Size(480, 360),
                     Mode = ResizeMode.Crop
                 }));
 

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,188 +1,110 @@
 import React from "react";
-import {
-  AlertDialog,
-  AlertDialogContent,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogAction,
-  AlertDialogCancel,
-} from "@/components/ui/alert-dialog";
-import { Button } from "@/components/ui/button";
-import { buttonVariants } from "@/components/ui/button-variants";
-import {
-  Sheet,
-  SheetTrigger,
-  SheetContent,
-  SheetTitle,
-  SheetDescription,
-  SheetHeader,
-} from "@/components/ui/sheet";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { toast } from "sonner";
-import { useAuthStore } from "../state/authStore";
-import { supabase } from "../supabaseClient";
 import { Link, useLocation } from "react-router-dom";
+import { useAuthStore } from "../state/authStore";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+
+const IconSpaces = () => (
+  <svg aria-hidden="true" viewBox="0 0 24 24" className="size-5" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M5 8h14M5 8a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v.286A2 2 0 0 1 19 8m-14 0v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8M10 12h4" />
+  </svg>
+);
+
+const IconProfile = () => (
+  <svg aria-hidden="true" viewBox="0 0 24 24" className="size-5" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="12" cy="8" r="4" />
+    <path d="M4 20c0-3.866 3.582-7 8-7s8 3.134 8 7" />
+  </svg>
+);
 
 const navLinks = [
-  { href: "/", label: "Get Started" },
-  { href: "/spaces", label: "Spaces" },
-  { href: "/profile", label: "Profile" },
-  { href: "/bulk", label: "Bulk Operations" },
+  { href: "/spaces", label: "Spaces", icon: <IconSpaces /> },
+  { href: "/profile", label: "Profile", icon: <IconProfile /> },
 ];
 
 const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [logoutDialogOpen, setLogoutDialogOpen] = React.useState(false);
   const user = useAuthStore((state) => state.user);
-  const setUser = useAuthStore((state) => state.setUser);
-  const setToken = useAuthStore((state) => state.setToken);
   const location = useLocation();
 
-  const handleLogout = async () => {
-    await supabase.auth.signOut();
-    setUser(null);
-    setToken(null);
-    toast.success("Logged out successfully");
-    setLogoutDialogOpen(false);
-  };
-
   const isActive = (href: string) =>
-    location.pathname === href || location.pathname.startsWith(href + "/");
+    href === "/" ? location.pathname === "/" : location.pathname.startsWith(href);
 
   return (
-    <div className="min-h-screen flex flex-col bg-gray-50">
-      <header className="bg-gray-900 text-white p-4 flex items-center justify-between">
-        <span className="font-bold text-lg">Storage Manager</span>
-        <div className="flex items-center gap-4">
+    <div className="min-h-screen flex flex-col bg-background">
+      {/* Top bar */}
+      <header className="sticky top-0 z-40 bg-card border-b border-border">
+        <div className="flex items-center h-14 px-4 gap-3">
+          <Link to="/spaces" className="font-semibold text-[15px] tracking-tight text-primary flex-1">
+            Storage Manager
+          </Link>
           {user && (
-            <div className="flex items-center gap-2">
-              <Avatar className="h-8 w-8">
-                <AvatarImage
-                  src={user.avatar_url || undefined}
-                  alt={user.full_name || user.email}
-                />
-                <AvatarFallback>
+            <Link to="/profile" aria-label="Your profile" className="flex items-center gap-2">
+              <span className="text-sm text-foreground/60 hidden sm:inline truncate max-w-[140px]">
+                {user.full_name || user.email}
+              </span>
+              <Avatar className="h-8 w-8 shrink-0">
+                <AvatarImage src={user.avatar_url || undefined} alt={user.full_name || user.email} />
+                <AvatarFallback className="text-xs bg-primary/10 text-primary">
                   {(user.full_name || user.email)?.[0]?.toUpperCase()}
                 </AvatarFallback>
               </Avatar>
-              <span
-                className="text-sm font-semibold"
-                aria-label="Logged in user name"
-              >
-                {user.full_name || user.email}
-              </span>
-            </div>
+            </Link>
           )}
-          <Sheet>
-            <SheetTrigger asChild>
-              <Button
-                className="md:hidden"
-                aria-label="Open navigation menu"
-                variant="ghost"
-              >
-                <svg
-                  width="24"
-                  height="24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  className="feather feather-menu"
-                >
-                  <line x1="3" y1="12" x2="21" y2="12" />
-                  <line x1="3" y1="6" x2="21" y2="6" />
-                  <line x1="3" y1="18" x2="21" y2="18" />
-                </svg>
-              </Button>
-            </SheetTrigger>
-            <SheetContent side="left">
-              <SheetHeader>
-                <SheetTitle className="sr-only">Menu</SheetTitle>
-                <SheetDescription className="sr-only">
-                  Storage Manager navigation
-                </SheetDescription>
-              </SheetHeader>
-              <nav className="p-4">
-                <ul className="space-y-2">
-                  {navLinks.map((link) => (
-                    <li key={link.href}>
-                      <Button
-                        asChild
-                        variant={isActive(link.href) ? "secondary" : "ghost"}
-                        className="w-full justify-start"
-                      >
-                        <Link to={link.href}>{link.label}</Link>
-                      </Button>
-                    </li>
-                  ))}
-                  {user && (
-                    <li>
-                      <Button
-                        onClick={() => setLogoutDialogOpen(true)}
-                        aria-label="Logout"
-                        variant="destructive"
-                        className="w-full mt-8"
-                      >
-                        Logout
-                      </Button>
-                    </li>
-                  )}
-                </ul>
-              </nav>
-            </SheetContent>
-          </Sheet>
         </div>
       </header>
+
+      {/* Layout body */}
       <div className="flex flex-1">
-        <aside className="hidden md:flex md:flex-col md:w-64 bg-white shadow-lg p-4">
-          <nav>
-            <ul className="space-y-2">
-              {navLinks.map((link) => (
-                <li key={link.href}>
-                  <Button
-                    asChild
-                    variant={isActive(link.href) ? "secondary" : "ghost"}
-                    className="w-full justify-start"
-                  >
-                    <Link to={link.href}>{link.label}</Link>
-                  </Button>
-                </li>
-              ))}
-              {user && (
-                <li>
-                  <Button
-                    onClick={() => setLogoutDialogOpen(true)}
-                    aria-label="Logout"
-                    variant="destructive"
-                    className="w-full mt-8"
-                  >
-                    Logout
-                  </Button>
-                  <AlertDialog open={logoutDialogOpen} onOpenChange={setLogoutDialogOpen}>
-                    <AlertDialogContent>
-                      <AlertDialogHeader>
-                        <AlertDialogTitle>Confirm logout</AlertDialogTitle>
-                        <AlertDialogDescription>
-                          Are you sure you want to log out?
-                        </AlertDialogDescription>
-                      </AlertDialogHeader>
-                      <AlertDialogFooter>
-                        <AlertDialogCancel>Cancel</AlertDialogCancel>
-                        <AlertDialogAction className={buttonVariants({ variant: "destructive" })} onClick={handleLogout}>
-                          Logout
-                        </AlertDialogAction>
-                      </AlertDialogFooter>
-                    </AlertDialogContent>
-                  </AlertDialog>
-                </li>
-              )}
-            </ul>
+        {/* Desktop sidebar */}
+        <aside className="hidden md:flex md:flex-col md:w-52 md:shrink-0 bg-sidebar border-r border-sidebar-border">
+          <nav className="p-3 flex flex-col gap-0.5" aria-label="Main navigation">
+            {navLinks.map((link) => {
+              const active = isActive(link.href);
+              return (
+                <Link
+                  key={link.href}
+                  to={link.href}
+                  className={`flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors ${
+                    active
+                      ? "bg-primary/10 text-primary"
+                      : "text-foreground/65 hover:bg-accent hover:text-foreground"
+                  }`}
+                >
+                  {link.icon}
+                  {link.label}
+                </Link>
+              );
+            })}
           </nav>
         </aside>
-        <main className="flex-1 p-4 md:ml-64">{children}</main>
+
+        {/* Main content */}
+        <main className="flex-1 min-w-0 pb-20 md:pb-0">
+          <div className="max-w-4xl mx-auto px-4 py-6">{children}</div>
+        </main>
       </div>
+
+      {/* Mobile bottom nav */}
+      <nav
+        className="md:hidden fixed bottom-0 inset-x-0 z-40 bg-card border-t border-border flex items-stretch"
+        style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
+        aria-label="Mobile navigation"
+      >
+        {navLinks.map((link) => {
+          const active = isActive(link.href);
+          return (
+            <Link
+              key={link.href}
+              to={link.href}
+              className={`flex flex-col items-center justify-center gap-1 flex-1 h-16 text-[10px] font-medium transition-colors ${
+                active ? "text-primary" : "text-foreground/45"
+              }`}
+            >
+              {link.icon}
+              {link.label}
+            </Link>
+          );
+        })}
+      </nav>
     </div>
   );
 };

--- a/src/components/BoxCard.tsx
+++ b/src/components/BoxCard.tsx
@@ -1,15 +1,12 @@
 import React, { useEffect, useRef, useState } from "react";
-import { resolveImageUrl, getCachedImageUrl } from "../lib/imageUrls"; // path relative to components directory
-import ImagePlaceholder from "./ImagePlaceholder";
+import { resolveImageUrl, getCachedImageUrl } from "../lib/imageUrls";
 
 export interface BoxCardProps {
-  id?: string; // optional (not currently used internally; retained for potential test ids)
+  id?: string;
   name: string;
   location?: string;
   itemCount?: number;
-  /** Optional signed URL already known */
   thumbnailUrl?: string;
-  /** Image id for lazy resolution */
   imageId?: string;
   onOpen?: () => void;
 }
@@ -17,46 +14,29 @@ export interface BoxCardProps {
 const BoxCard: React.FC<BoxCardProps> = ({ name, location, itemCount, thumbnailUrl, imageId, onOpen }) => {
   const ref = useRef<HTMLDivElement | null>(null);
   const [visible, setVisible] = useState(false);
-  const [loading, setLoading] = useState(false);
-  const [resolvedUrl, setResolvedUrl] = useState<string | undefined>(() => (imageId ? getCachedImageUrl(imageId) || undefined : undefined));
+  const [resolvedUrl, setResolvedUrl] = useState<string | undefined>(
+    () => (imageId ? getCachedImageUrl(imageId) || undefined : undefined)
+  );
 
-  // Intersection observer to trigger load
   useEffect(() => {
-    if (!imageId || thumbnailUrl) return; // nothing to lazy load
-    if (resolvedUrl) return; // already have it
+    if (!imageId || thumbnailUrl || resolvedUrl) return;
     const node = ref.current;
     if (!node) return;
     const observer = new IntersectionObserver(
-      entries => {
-        entries.forEach(entry => {
-          if (entry.isIntersecting) {
-            setVisible(true);
-          }
-        });
-      },
-      { rootMargin: "100px" }, // pre-load slightly before visible
+      (entries) => entries.forEach((e) => e.isIntersecting && setVisible(true)),
+      { rootMargin: "100px" }
     );
     observer.observe(node);
     return () => observer.disconnect();
   }, [imageId, thumbnailUrl, resolvedUrl]);
 
-  // Resolve URL once visible
   useEffect(() => {
-    if (!visible) return;
-    if (!imageId || resolvedUrl || thumbnailUrl) return;
+    if (!visible || !imageId || resolvedUrl || thumbnailUrl) return;
     let cancelled = false;
-    setLoading(true);
     resolveImageUrl(imageId)
       .catch(() => null)
-      .then(url => {
-        if (!cancelled) setResolvedUrl(url || undefined);
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
+      .then((url) => { if (!cancelled) setResolvedUrl(url || undefined); });
+    return () => { cancelled = true; };
   }, [visible, imageId, resolvedUrl, thumbnailUrl]);
 
   const finalUrl = thumbnailUrl || resolvedUrl;
@@ -64,22 +44,35 @@ const BoxCard: React.FC<BoxCardProps> = ({ name, location, itemCount, thumbnailU
   return (
     <div
       ref={ref}
-      className="bg-white rounded shadow p-4 flex items-center cursor-pointer"
+      className="relative group flex flex-col rounded-xl border border-border bg-card overflow-hidden cursor-pointer transition-all hover:border-primary/30 hover:shadow-sm focus-visible:ring-2 focus-visible:ring-ring outline-none"
       onClick={onOpen}
+      tabIndex={0}
+      onKeyDown={(e) => e.key === "Enter" && onOpen?.()}
       aria-label={`Open box ${name}`}
+      role="button"
     >
-      {finalUrl ? (
-        <img src={finalUrl} alt={`${name} image`} className="w-12 h-12 rounded mr-4 object-cover" />
-      ) : imageId ? (
-        <ImagePlaceholder className="w-12 h-12 rounded mr-4" loading={loading} label="Loading image" />
-      ) : (
-        <ImagePlaceholder className="w-12 h-12 rounded mr-4" label="No image" />
-      )}
-      <div className="flex-1">
-        <h3 className="text-md font-semibold">{name}</h3>
-        {location && <p className="text-xs text-gray-500">{location}</p>}
+      {/* Image */}
+      <div className="aspect-[3/2] w-full bg-muted overflow-hidden">
+        {finalUrl ? (
+          <img src={finalUrl} alt={`${name} image`} className="w-full h-full object-cover" loading="lazy" />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center text-muted-foreground/30">
+            <svg viewBox="0 0 24 24" className="size-8" fill="none" stroke="currentColor" strokeWidth="1" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z" />
+              <path d="m3.3 7 8.7 5 8.7-5M12 22V12" />
+            </svg>
+          </div>
+        )}
+      </div>
+
+      {/* Info */}
+      <div className="p-3 flex flex-col gap-0.5">
+        <p className="font-semibold text-[14px] leading-snug line-clamp-1" title={name}>{name}</p>
+        {location && <p className="text-xs text-muted-foreground line-clamp-1">{location}</p>}
         {typeof itemCount === "number" && (
-          <p className="text-xs text-gray-400">Items: {itemCount}</p>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            {itemCount} {itemCount === 1 ? "item" : "items"}
+          </p>
         )}
       </div>
     </div>

--- a/src/components/ItemRow.tsx
+++ b/src/components/ItemRow.tsx
@@ -11,10 +11,11 @@ export interface ItemRowProps {
 
 const ItemRow: React.FC<ItemRowProps> = ({ name, description, quantity, thumbnailUrl, onOpen }) => (
   <li
+    role="button"
     className="flex items-center gap-3 px-2 py-2.5 rounded-lg hover:bg-accent cursor-pointer transition-colors group"
     onClick={onOpen}
     tabIndex={0}
-    onKeyDown={(e) => e.key === "Enter" && onOpen?.()}
+    onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && (e.preventDefault(), onOpen?.())}
     aria-label={`Open item ${name}`}
   >
     {/* Thumbnail */}

--- a/src/components/ItemRow.tsx
+++ b/src/components/ItemRow.tsx
@@ -10,14 +10,41 @@ export interface ItemRowProps {
 }
 
 const ItemRow: React.FC<ItemRowProps> = ({ name, description, quantity, thumbnailUrl, onOpen }) => (
-  <div className="flex items-center p-2 border-b cursor-pointer" onClick={onOpen} aria-label={`Open item ${name}`}>
-    {thumbnailUrl && <img src={thumbnailUrl} alt={`${name} image`} className="w-8 h-8 rounded mr-2" />}
-    <div className="flex-1">
-      <span className="font-medium">{name}</span>
-      <span className="text-xs text-gray-500 ml-2">{description}</span>
+  <li
+    className="flex items-center gap-3 px-2 py-2.5 rounded-lg hover:bg-accent cursor-pointer transition-colors group"
+    onClick={onOpen}
+    tabIndex={0}
+    onKeyDown={(e) => e.key === "Enter" && onOpen?.()}
+    aria-label={`Open item ${name}`}
+  >
+    {/* Thumbnail */}
+    <div className="size-10 rounded-lg overflow-hidden bg-muted shrink-0 flex items-center justify-center text-muted-foreground/30">
+      {thumbnailUrl ? (
+        <img src={thumbnailUrl} alt="" className="w-full h-full object-cover" loading="lazy" />
+      ) : (
+        <svg viewBox="0 0 24 24" className="size-5" fill="none" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <rect x="3" y="3" width="18" height="18" rx="2" />
+          <circle cx="8.5" cy="8.5" r="1.5" />
+          <path d="m21 15-5-5L5 21" />
+        </svg>
+      )}
     </div>
-    <span className="text-xs text-gray-400">Qty: {quantity}</span>
-  </div>
+
+    {/* Text */}
+    <div className="flex-1 min-w-0">
+      <p className="text-sm font-medium leading-snug line-clamp-1">{name}</p>
+      {description && (
+        <p className="text-xs text-muted-foreground line-clamp-1 mt-0.5">{description}</p>
+      )}
+    </div>
+
+    {/* Quantity */}
+    {typeof quantity === "number" && (
+      <span className="text-sm font-medium text-muted-foreground tabular-nums shrink-0">
+        ×{quantity}
+      </span>
+    )}
+  </li>
 );
 
 export default ItemRow;

--- a/src/components/SpaceCard.tsx
+++ b/src/components/SpaceCard.tsx
@@ -69,7 +69,7 @@ const SpaceCard: React.FC<SpaceCardProps> = ({
       className="relative group flex flex-col rounded-xl border border-border bg-card overflow-hidden cursor-pointer transition-all hover:border-primary/30 hover:shadow-sm focus-visible:ring-2 focus-visible:ring-ring outline-none"
       onClick={onOpen}
       tabIndex={0}
-      onKeyDown={(e) => e.key === "Enter" && onOpen?.()}
+      onKeyDown={(e) => e.target === e.currentTarget && (e.key === "Enter" || e.key === " ") && (e.preventDefault(), onOpen?.())}
       aria-label={`Open space ${name}`}
       role="button"
     >

--- a/src/components/SpaceCard.tsx
+++ b/src/components/SpaceCard.tsx
@@ -1,8 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
-import { Users } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { useSpacesStore } from "@/state/spacesStore";
-import { Button } from "@/components/ui/button";
 import { TrashIcon } from "@/components/ui/trash-icon";
 import { toast } from "sonner";
 import { resolveImageUrl, getCachedImageUrl } from "@/lib/imageUrls";
@@ -14,47 +12,43 @@ export interface SpaceCardProps {
   memberCount?: number;
   boxCount?: number;
   owner?: string | null;
-  /** Optional signed URL already known (e.g., recently uploaded) */
   thumbnailUrl?: string;
-  /** optional persisted image id (UUID) for server-side stored thumbnails */
   imageId?: string | null;
   onOpen?: () => void;
-  /** Indicates space is not owned by current user */
   isShared?: boolean;
-  /** Owner display name (tooltip) */
   ownerName?: string;
-  /** Current user's membership role when shared */
   role?: string;
-  /** Delete handler (only for owned spaces) */
   onDelete?: () => void;
 }
 
-const SpaceCard: React.FC<SpaceCardProps> = ({ name, location, memberCount, boxCount, owner, thumbnailUrl, imageId, onOpen, isShared, ownerName, role, onDelete }) => {
+const SpaceCard: React.FC<SpaceCardProps> = ({
+  name, location, memberCount, boxCount, thumbnailUrl, imageId,
+  onOpen, isShared, ownerName, owner, role, onDelete,
+}) => {
   const canDelete = (boxCount ?? 0) === 0;
   const setSpaceImageUrl = useSpacesStore((s) => s.setSpaceImageUrl);
   const ref = useRef<HTMLDivElement | null>(null);
   const [visible, setVisible] = useState(false);
   const [erroredThumb, setErroredThumb] = useState(false);
-  const [resolvedUrl, setResolvedUrl] = useState<string | undefined>(() => (imageId ? getCachedImageUrl(imageId) || undefined : undefined));
+  const [resolvedUrl, setResolvedUrl] = useState<string | undefined>(
+    () => (imageId ? getCachedImageUrl(imageId) || undefined : undefined)
+  );
 
-  // Observe visibility for lazy load (skip if thumbnailUrl already provided)
   useEffect(() => {
-    if (!imageId || thumbnailUrl) return;
-    if (resolvedUrl) return;
+    if (!imageId || thumbnailUrl || resolvedUrl) return;
     const node = ref.current;
     if (!node) return;
-    const observer = new IntersectionObserver((entries) => {
-      entries.forEach((e) => e.isIntersecting && setVisible(true));
-    }, { rootMargin: "200px" });
+    const observer = new IntersectionObserver(
+      (entries) => entries.forEach((e) => e.isIntersecting && setVisible(true)),
+      { rootMargin: "200px" }
+    );
     observer.observe(node);
     return () => observer.disconnect();
   }, [imageId, thumbnailUrl, resolvedUrl]);
 
-  // Resolve when visible
   useEffect(() => {
-    if (!imageId || resolvedUrl || thumbnailUrl) return;
-    if (!visible) return;
-  let cancelled = false;
+    if (!imageId || resolvedUrl || thumbnailUrl || !visible) return;
+    let cancelled = false;
     setErroredThumb(false);
     resolveImageUrl(imageId)
       .then((u) => {
@@ -63,8 +57,7 @@ const SpaceCard: React.FC<SpaceCardProps> = ({ name, location, memberCount, boxC
           try { setSpaceImageUrl(imageId, u); } catch { /* ignore */ }
         }
       })
-      .catch(() => { if (!cancelled) setErroredThumb(true); })
-  .finally(() => { /* no-op */ });
+      .catch(() => { if (!cancelled) setErroredThumb(true); });
     return () => { cancelled = true; };
   }, [visible, imageId, resolvedUrl, thumbnailUrl, setSpaceImageUrl]);
 
@@ -72,95 +65,83 @@ const SpaceCard: React.FC<SpaceCardProps> = ({ name, location, memberCount, boxC
 
   return (
     <div
-  ref={ref}
-      className={`relative group bg-white rounded shadow p-4 flex items-center cursor-pointer transition-colors ${
-        isShared ? "bg-indigo-50 dark:bg-indigo-900/20" : "bg-background hover:bg-accent/50"
-      }`}
+      ref={ref}
+      className="relative group flex flex-col rounded-xl border border-border bg-card overflow-hidden cursor-pointer transition-all hover:border-primary/30 hover:shadow-sm focus-visible:ring-2 focus-visible:ring-ring outline-none"
       onClick={onOpen}
+      tabIndex={0}
+      onKeyDown={(e) => e.key === "Enter" && onOpen?.()}
       aria-label={`Open space ${name}`}
+      role="button"
     >
-      {!isShared && (
-        canDelete && onDelete ? (
-          <Button
-            type="button"
-            variant="destructive"
-            size="sm"
-            className="absolute top-2 right-2 h-7 w-7 p-0 opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus-visible:opacity-100 transition-opacity"
-            onClick={(e) => {
-              e.stopPropagation();
-              onDelete();
-            }}
-            aria-label={`Delete space ${name}`}
-          >
-            <TrashIcon size={16} aria-hidden="true" />
-          </Button>
+      {/* Image */}
+      <div className="aspect-[4/3] w-full bg-muted overflow-hidden relative">
+        {finalUrl && !erroredThumb ? (
+          <img
+            src={finalUrl}
+            alt={`${name} image`}
+            className="w-full h-full object-cover"
+            loading="lazy"
+            onError={() => setErroredThumb(true)}
+          />
         ) : (
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              // show toast or inline state
-              toast.info("Remove all boxes before deleting this space.");
-            }}
-            className="absolute top-2 right-2 h-7 w-7 p-0 flex items-center justify-center rounded border border-dashed text-muted-foreground text-[10px]"
-            aria-label="Cannot delete space (contains boxes)"
-            aria-disabled="true"
-          >
-            <TrashIcon size={14} aria-hidden="true" />
-          </button>
-        )
-      )}
-      {/* Render resolved image when available and not errored, otherwise show placeholder (150x150). */}
-      {finalUrl && !erroredThumb ? (
-        <img
-          src={finalUrl}
-          alt={`${name} image`}
-          className="w-16 h-16 rounded object-cover mr-4 border"
-          loading="lazy"
-          onError={() => setErroredThumb(true)}
-        />
-      ) : (
-        <img
-          src={`data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='150' height='150'><rect width='100%25' height='100%25' fill='%23e5e7eb'/><text x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' fill='%239ca3af' font-family='Arial, Helvetica, sans-serif' font-size='18'>No image</text></svg>`}
-          alt=""
-          aria-hidden="true"
-          className="w-16 h-16 rounded object-cover mr-4 border"
-          loading="lazy"
-        />
-      )}
-      <div className="flex-1">
-        <div className="flex items-center gap-2">
-          {isShared && (
-            <span
-              className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-indigo-600 text-[10px] font-medium text-white"
-              title={`Owned by ${ownerName || owner || "another user"}`}
+          <div className="w-full h-full flex items-center justify-center text-muted-foreground/35">
+            <svg viewBox="0 0 24 24" className="size-10" fill="none" stroke="currentColor" strokeWidth="1" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M5 8h14M5 8a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v.286A2 2 0 0 1 19 8m-14 0v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8" />
+            </svg>
+          </div>
+        )}
+        {/* Delete button */}
+        {!isShared && (
+          canDelete && onDelete ? (
+            <button
+              type="button"
+              className="absolute top-2 right-2 h-7 w-7 flex items-center justify-center rounded-lg bg-card/90 border border-border text-destructive opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity hover:bg-card"
+              onClick={(e) => { e.stopPropagation(); onDelete(); }}
+              aria-label={`Delete space ${name}`}
             >
-              <Users size={14} />
+              <TrashIcon size={14} aria-hidden="true" />
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={(e) => { e.stopPropagation(); toast.info("Remove all boxes before deleting this space."); }}
+              className="absolute top-2 right-2 h-7 w-7 flex items-center justify-center rounded-lg bg-card/60 border border-dashed border-muted-foreground/25 text-muted-foreground/35 opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity"
+              aria-label="Cannot delete space (contains boxes)"
+              aria-disabled="true"
+            >
+              <TrashIcon size={13} aria-hidden="true" />
+            </button>
+          )
+        )}
+        {/* Shared badge */}
+        {isShared && (
+          <span className="absolute top-2 left-2 text-[10px] font-semibold uppercase tracking-wide bg-card/85 text-foreground/70 rounded-full px-2 py-0.5 border border-border">
+            Shared
+          </span>
+        )}
+      </div>
+
+      {/* Info */}
+      <div className="p-3 flex flex-col gap-0.5">
+        <p className="font-semibold text-[14px] leading-snug line-clamp-1" title={name}>{name}</p>
+        {location && <p className="text-xs text-muted-foreground line-clamp-1">{location}</p>}
+        <div className="flex items-center gap-2 mt-1 flex-wrap">
+          {typeof boxCount === "number" && (
+            <span className="text-xs text-muted-foreground">
+              {boxCount} {boxCount === 1 ? "box" : "boxes"}
             </span>
           )}
-          <span className="font-medium line-clamp-1" title={name}>{name}</span>
-          {typeof boxCount === "number" && (
-            <Badge variant="secondary" className="ml-1">
-              {boxCount} {boxCount === 1 ? "box" : "boxes"}
+          {typeof memberCount === "number" && memberCount > 1 && (
+            <span className="text-xs text-muted-foreground">· {memberCount} members</span>
+          )}
+          {isShared && role && (
+            <Badge variant="outline" className="text-[10px] uppercase tracking-wide h-4 px-1.5">
+              {role}
             </Badge>
           )}
         </div>
-        {isShared && (
-          <div className="flex items-center gap-2 mt-1 flex-wrap">
-            <Badge variant="outline">Shared</Badge>
-            {role && (
-              <Badge variant="secondary" title={`Your role: ${role}`} className="uppercase tracking-wide text-[10px]">
-                {role}
-              </Badge>
-            )}
-          </div>
-        )}
-        {location && <p className="text-sm text-muted-foreground mt-1">{location}</p>}
-        <p className="text-xs text-gray-400 mt-1">Members: {memberCount ?? 0} {owner && (`| Owner: ${owner}`)}</p>
-        {boxCount && boxCount > 0 && (
-          <p className="hidden non-empty-hint-touch mt-1 text-[11px] text-muted-foreground">
-            Remove boxes to delete.
-          </p>
+        {isShared && (ownerName || owner) && (
+          <p className="text-xs text-muted-foreground/65 mt-0.5 truncate">By {ownerName || owner}</p>
         )}
       </div>
     </div>

--- a/src/components/SpacesSection.tsx
+++ b/src/components/SpacesSection.tsx
@@ -6,27 +6,24 @@ export interface SpacesSectionProps {
   emptyMessage?: string;
 }
 
-/**
- * Grouped list of spaces under a labeled section with a count badge.
- */
 export function SpacesSection({ title, spaces, emptyMessage }: SpacesSectionProps) {
   if (!spaces.length) {
     if (!emptyMessage) return null;
     return (
-      <section className="space-y-2">
-        <h3 className="sticky top-0 z-10 bg-background/80 py-1 text-xs font-semibold uppercase tracking-wide backdrop-blur">
-          {title} <span className="text-muted-foreground">(0)</span>
+      <section>
+        <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+          {title} <span className="opacity-60">(0)</span>
         </h3>
-        <div className="text-sm text-muted-foreground italic px-2">{emptyMessage}</div>
+        <p className="text-sm text-muted-foreground">{emptyMessage}</p>
       </section>
     );
   }
   return (
-    <section className="space-y-2">
-      <h3 className="sticky top-0 z-10 bg-background/80 py-1 text-xs font-semibold uppercase tracking-wide backdrop-blur flex items-center gap-2">
-        {title} <span className="text-muted-foreground">({spaces.length})</span>
+    <section>
+      <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3">
+        {title} <span className="opacity-60">({spaces.length})</span>
       </h3>
-      <div className="grid gap-2">
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
         {spaces.map((s) => (
           <SpaceCard key={s.id} {...s} />
         ))}

--- a/src/hooks/useEntityUpdate.ts
+++ b/src/hooks/useEntityUpdate.ts
@@ -3,6 +3,10 @@ import { useSpacesStore } from "@/state/spacesStore";
 import { useBoxesStore } from "@/state/boxesStore";
 import { supabase } from "@/supabaseClient";
 import type { Box, Space } from "@/types/entities";
+import type { Database } from "@/types/database.types";
+
+type TablesUpdate<T extends keyof Database["public"]["Tables"]> =
+    Database["public"]["Tables"][T]["Update"];
 
 type Kind = "space" | "box";
 
@@ -31,7 +35,7 @@ export function useEntityUpdate<TPatch extends Record<string, unknown>>(
             const dbPatch = mapPatchToDb ? mapPatchToDb(patch) : patch;
             if (kind === "space") {
                 const { error: err } = await supabase.from("spaces").update(
-                    dbPatch as Partial<Omit<Space, "boxCount">>,
+                    dbPatch as TablesUpdate<"spaces">,
                 ).eq("id", entity.id);
                 if (err) throw err;
                 const updatedBase: Space = {
@@ -48,7 +52,7 @@ export function useEntityUpdate<TPatch extends Record<string, unknown>>(
                 onSuccess?.(updated);
             } else {
                 const { error: err } = await supabase.from("boxes").update(
-                    dbPatch as Partial<Box>,
+                    dbPatch as TablesUpdate<"boxes">,
                 ).eq("id", entity.id);
                 if (err) throw err;
                 const updatedBase: Box = {

--- a/src/hooks/useEntityUpdate.ts
+++ b/src/hooks/useEntityUpdate.ts
@@ -31,7 +31,7 @@ export function useEntityUpdate<TPatch extends Record<string, unknown>>(
             const dbPatch = mapPatchToDb ? mapPatchToDb(patch) : patch;
             if (kind === "space") {
                 const { error: err } = await supabase.from("spaces").update(
-                    dbPatch,
+                    dbPatch as Partial<Omit<Space, "boxCount">>,
                 ).eq("id", entity.id);
                 if (err) throw err;
                 const updatedBase: Space = {
@@ -48,7 +48,7 @@ export function useEntityUpdate<TPatch extends Record<string, unknown>>(
                 onSuccess?.(updated);
             } else {
                 const { error: err } = await supabase.from("boxes").update(
-                    dbPatch,
+                    dbPatch as Partial<Box>,
                 ).eq("id", entity.id);
                 if (err) throw err;
                 const updatedBase: Box = {

--- a/src/index.css
+++ b/src/index.css
@@ -1,68 +1,13 @@
+/* Base resets only — design tokens and Tailwind live in style.css */
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
 }

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -14,14 +14,12 @@ const Auth: React.FC = () => {
   );
   const user = useAuthStore(s => s.user);
 
-  // Persist desired redirect early (before OAuth redirect happens)
   React.useEffect(() => {
     if (redirectParam) {
       window.localStorage.setItem('post_auth_redirect', redirectParam);
     }
   }, [redirectParam]);
 
-  // If already authenticated (e.g., returned from provider) send user onward
   React.useEffect(() => {
     if (user) {
       const pending = window.localStorage.getItem('post_auth_redirect') || '/';
@@ -33,57 +31,56 @@ const Auth: React.FC = () => {
   const handleGoogleLogin = async () => {
     const { error } = await supabase.auth.signInWithOAuth({
       provider: 'google',
-      options: {
-        redirectTo: window.location.origin, // after provider, Root/App effect handles redirect
-      },
+      options: { redirectTo: window.location.origin },
     });
-    if (error) {
-      alert('Google sign-in failed: ' + error.message);
-    }
+    if (error) alert('Google sign-in failed: ' + error.message);
   };
+
   const handleFacebookLogin = async () => {
     const { error } = await supabase.auth.signInWithOAuth({
       provider: 'facebook',
-      options: {
-        redirectTo: window.location.origin,
-      }
+      options: { redirectTo: window.location.origin },
     });
-    if (error) {
-      alert('Facebook sign-in failed: ' + error.message);
-    }
+    if (error) alert('Facebook sign-in failed: ' + error.message);
   };
+
   const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-gray-50">
-      <div className="w-full max-w-sm bg-white rounded shadow p-6">
-        <h1 className="text-2xl font-bold mb-2 text-center">Sign In / Sign Up</h1>
-        <h2 className="text-1xl mb-6 text-center">Get started organizing your storage spaces</h2>
-        <Button
-          size="sm"
-          className="w-full mb-4 gap-2"
-          onClick={handleGoogleLogin}
-          aria-label="Sign in with Google"
-        >
-          <svg aria-hidden="true" viewBox="0 0 48 48" className="h-4 w-4"><g><path fill="#4285F4" d="M24 9.5c3.54 0 6.7 1.22 9.19 3.22l6.85-6.85C35.62 2.36 30.13 0 24 0 14.61 0 6.44 5.74 2.44 14.09l8.01 6.23C12.6 13.16 17.87 9.5 24 9.5z"/><path fill="#34A853" d="M46.1 24.5c0-1.64-.15-3.22-.43-4.75H24v9.02h12.44c-.54 2.92-2.18 5.39-4.64 7.05l7.19 5.59C43.98 37.36 46.1 31.41 46.1 24.5z"/><path fill="#FBBC05" d="M10.45 28.32c-1.01-2.99-1.01-6.23 0-9.22l-8.01-6.23C.64 16.36 0 20.07 0 24c0 3.93.64 7.64 2.44 11.13l8.01-6.23z"/><path fill="#EA4335" d="M24 46c6.13 0 11.62-2.02 15.94-5.5l-7.19-5.59c-2.01 1.35-4.59 2.15-7.75 2.15-6.13 0-11.4-3.66-13.55-8.82l-8.01 6.23C6.44 42.26 14.61 48 24 48z"/></g></svg>
-          <span>Sign in with Google</span>
-        </Button>
-        <Button
-          size="sm"
-          className="w-full mb-4 gap-2"
-          onClick={handleFacebookLogin}
-          aria-label="Sign in with Facebook"
-        >
-          <svg aria-hidden="true" viewBox="0 0 48 48" className="h-4 w-4"><path fill="#1877F2" d="M24 0C10.745 0 0 10.745 0 24c0 12.02 8.805 21.92 20.205 23.74V31.09h-6.08v-7.09h6.08v-5.41c0-6.02 3.66-9.34 9.13-9.34 2.64 0 5.41.47 5.41.47v5.96h-3.05c-3.01 0-3.95 1.87-3.95 3.79v4.53h6.72l-1.07 7.09h-5.65v16.65C39.195 45.92 48 36.02 48 24 48 10.745 37.255 0 24 0z"/></svg>
-          <span>Sign in with Facebook</span>
-        </Button>
-        <Alert variant="default" className="mb-4">
-          <AlertTitle>Disclaimer</AlertTitle>
-            <AlertDescription>
-            We use Supabase for authentication <span className="break-all">({supabaseUrl}).</span>
-            Because we are on a free Supabase plan, we cannot use custom domains for OAuth redirects.
-            Therefore you will see the above Supabase-generated domain during sign-in.
-            This is expected and does not affect your security.
-            </AlertDescription>
+    <div className="min-h-screen flex flex-col items-center justify-center bg-background px-4">
+      <div className="w-full max-w-sm bg-card rounded-2xl border border-border p-8">
+        <div className="mb-8 text-center">
+          <p className="text-xs font-semibold uppercase tracking-widest text-primary mb-2">Storage Manager</p>
+          <h1 className="text-2xl font-semibold text-foreground mb-1">Welcome back</h1>
+          <p className="text-sm text-muted-foreground">Sign in to organize your storage spaces</p>
+        </div>
+
+        <div className="flex flex-col gap-3 mb-6">
+          <Button
+            variant="outline"
+            className="w-full gap-2.5 h-11"
+            onClick={handleGoogleLogin}
+            aria-label="Sign in with Google"
+          >
+            <svg aria-hidden="true" viewBox="0 0 48 48" className="h-4 w-4 shrink-0"><g><path fill="#4285F4" d="M24 9.5c3.54 0 6.7 1.22 9.19 3.22l6.85-6.85C35.62 2.36 30.13 0 24 0 14.61 0 6.44 5.74 2.44 14.09l8.01 6.23C12.6 13.16 17.87 9.5 24 9.5z"/><path fill="#34A853" d="M46.1 24.5c0-1.64-.15-3.22-.43-4.75H24v9.02h12.44c-.54 2.92-2.18 5.39-4.64 7.05l7.19 5.59C43.98 37.36 46.1 31.41 46.1 24.5z"/><path fill="#FBBC05" d="M10.45 28.32c-1.01-2.99-1.01-6.23 0-9.22l-8.01-6.23C.64 16.36 0 20.07 0 24c0 3.93.64 7.64 2.44 11.13l8.01-6.23z"/><path fill="#EA4335" d="M24 46c6.13 0 11.62-2.02 15.94-5.5l-7.19-5.59c-2.01 1.35-4.59 2.15-7.75 2.15-6.13 0-11.4-3.66-13.55-8.82l-8.01 6.23C6.44 42.26 14.61 48 24 48z"/></g></svg>
+            Continue with Google
+          </Button>
+          <Button
+            variant="outline"
+            className="w-full gap-2.5 h-11"
+            onClick={handleFacebookLogin}
+            aria-label="Sign in with Facebook"
+          >
+            <svg aria-hidden="true" viewBox="0 0 48 48" className="h-4 w-4 shrink-0"><path fill="#1877F2" d="M24 0C10.745 0 0 10.745 0 24c0 12.02 8.805 21.92 20.205 23.74V31.09h-6.08v-7.09h6.08v-5.41c0-6.02 3.66-9.34 9.13-9.34 2.64 0 5.41.47 5.41.47v5.96h-3.05c-3.01 0-3.95 1.87-3.95 3.79v4.53h6.72l-1.07 7.09h-5.65v16.65C39.195 45.92 48 36.02 48 24 48 10.745 37.255 0 24 0z"/></svg>
+            Continue with Facebook
+          </Button>
+        </div>
+
+        <Alert variant="default" className="text-xs">
+          <AlertTitle className="text-xs font-semibold">Note on OAuth redirect</AlertTitle>
+          <AlertDescription className="text-xs text-muted-foreground">
+            We use Supabase for auth <span className="break-all">({supabaseUrl})</span>. On the free plan, OAuth redirects show a Supabase domain. This is expected and safe.
+          </AlertDescription>
         </Alert>
       </div>
     </div>

--- a/src/pages/BoxDetail.tsx
+++ b/src/pages/BoxDetail.tsx
@@ -173,12 +173,18 @@ const BoxDetail: React.FC = () => {
               <ImagePlaceholder className="h-40 w-40 rounded" />
             )}
           </div>
-          <div className="mb-2"><span className="font-semibold">Location:</span> {box.location || <span className="text-muted-foreground">(none)</span>}</div>
-          <div className="mb-2"><span className="font-semibold">Content:</span><br />
-            <div className="whitespace-pre-line border rounded p-2 bg-muted">{box.content || <span className="text-muted-foreground">(none)</span>}</div>
+          <div className="mb-4 text-sm">
+            <span className="text-muted-foreground">Location:</span>{" "}
+            {box.location || <span className="text-muted-foreground/60">(none)</span>}
           </div>
-          <div className="mb-2"><span className="font-semibold">Created:</span> {box.created_at ? new Date(box.created_at).toLocaleString() : <span className="text-muted-foreground">(unknown)</span>}</div>
-          <div className="mb-2"><span className="font-semibold">Modified:</span> {box.modified_at ? new Date(box.modified_at).toLocaleString() : <span className="text-muted-foreground">(unknown)</span>}</div>
+          <div className="mb-4">
+            <p className="text-muted-foreground text-sm mb-1">Content</p>
+            <div className="whitespace-pre-line rounded-lg border border-border bg-muted/40 p-3 text-sm">{box.content || <span className="text-muted-foreground/60">(none)</span>}</div>
+          </div>
+          <div className="flex gap-6 text-xs text-muted-foreground">
+            <span>Created: {box.created_at ? new Date(box.created_at).toLocaleString() : <span className="opacity-60">(unknown)</span>}</span>
+            <span>Modified: {box.modified_at ? new Date(box.modified_at).toLocaleString() : <span className="opacity-60">(unknown)</span>}</span>
+          </div>
         </div>
       )}
       <EditBoxModal open={editOpen} onClose={() => setEditOpen(false)} box={box} />

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,46 +1,95 @@
 import React from "react";
 import AppShell from "../components/AppShell";
 import { useAuthStore } from "../state/authStore";
-import { Card, CardContent } from "@/components/ui/card";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { buttonVariants } from "@/components/ui/button-variants";
+import { AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle, AlertDialogDescription, AlertDialogFooter, AlertDialogCancel, AlertDialogAction } from "@/components/ui/alert-dialog";
+import { toast } from "sonner";
+import { supabase } from "../supabaseClient";
+import { useNavigate } from "react-router-dom";
 
 const Profile: React.FC = () => {
   const user = useAuthStore((state) => state.user);
+  const setUser = useAuthStore((state) => state.setUser);
+  const setToken = useAuthStore((state) => state.setToken);
+  const navigate = useNavigate();
+  const [logoutOpen, setLogoutOpen] = React.useState(false);
+
+  const handleLogout = async () => {
+    await supabase.auth.signOut();
+    setUser(null);
+    setToken(null);
+    toast.success("Signed out");
+    navigate("/auth");
+  };
+
   return (
     <AppShell>
-      <h1 className="text-2xl font-bold mb-4">User Profile</h1>
+      <h1 className="text-xl font-semibold tracking-tight mb-5">Profile</h1>
+
       {user ? (
-        <Card className="w-full max-w-md mb-4">
-          <CardContent className="p-6">
-            <div className="flex items-center gap-4 mb-4">
-              <Avatar className="h-16 w-16">
-                <AvatarImage src={user.avatar_url || undefined} alt={user.full_name || user.email} />
-                <AvatarFallback>{(user.full_name || user.email)?.[0]?.toUpperCase()}</AvatarFallback>
-              </Avatar>
-              <div>
-                <span className="block text-lg font-semibold">{user.full_name || user.email}</span>
-                <span className="block text-sm text-gray-500">{user.email}</span>
+        <div className="flex flex-col gap-4 max-w-sm">
+          {/* Identity card */}
+          <div className="bg-card rounded-xl border border-border p-5 flex items-center gap-4">
+            <Avatar className="h-14 w-14 shrink-0">
+              <AvatarImage src={user.avatar_url || undefined} alt={user.full_name || user.email} />
+              <AvatarFallback className="text-lg bg-primary/10 text-primary">
+                {(user.full_name || user.email)?.[0]?.toUpperCase()}
+              </AvatarFallback>
+            </Avatar>
+            <div className="min-w-0">
+              <p className="font-semibold text-[15px] truncate">{user.full_name || user.email}</p>
+              {user.full_name && (
+                <p className="text-sm text-muted-foreground truncate">{user.email}</p>
+              )}
+            </div>
+          </div>
+
+          {/* Roles */}
+          {user.roles && user.roles.length > 0 && (
+            <div className="bg-card rounded-xl border border-border p-5">
+              <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2">Roles</p>
+              <div className="flex flex-wrap gap-1.5">
+                {user.roles.map((role, idx) => (
+                  <Badge key={idx} variant="secondary" className="text-xs">{role}</Badge>
+                ))}
               </div>
             </div>
-            <div>
-              <span className="font-semibold">Roles:</span>
-              <div className="flex flex-wrap gap-2 mt-2">
-                {user.roles && user.roles.length > 0 ? (
-                  user.roles.map((role, idx) => (
-                    <Badge key={idx} variant="secondary">{role}</Badge>
-                  ))
-                ) : (
-                  <Badge variant="outline">No roles assigned</Badge>
-                )}
-              </div>
-            </div>
-          </CardContent>
-        </Card>
+          )}
+
+          {/* Sign out */}
+          <Button
+            variant="outline"
+            className="w-full text-destructive border-destructive/30 hover:bg-destructive/5 hover:border-destructive/50"
+            onClick={() => setLogoutOpen(true)}
+          >
+            Sign out
+          </Button>
+
+          <AlertDialog open={logoutOpen} onOpenChange={setLogoutOpen}>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Sign out?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  You'll need to sign in again to access your spaces.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction
+                  className={buttonVariants({ variant: "destructive" })}
+                  onClick={handleLogout}
+                >
+                  Sign out
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </div>
       ) : (
-        <Card className="max-w-md mx-auto">
-          <CardContent className="p-6 text-center text-gray-500">Not logged in.</CardContent>
-        </Card>
+        <p className="text-sm text-muted-foreground">Not signed in.</p>
       )}
     </AppShell>
   );

--- a/src/pages/SpaceDetail.tsx
+++ b/src/pages/SpaceDetail.tsx
@@ -160,9 +160,9 @@ const SpaceDetail: React.FC = () => {
           </div>
         )}
       </div>
-      <div className="mb-2 text-muted-foreground">Location: {space.location}</div>
-      <div className="mb-2">
-        <h2 className="text-sm font-semibold text-muted-foreground mb-1">Members</h2>
+      <div className="mb-4 text-sm text-muted-foreground">{space.location}</div>
+      <div className="mb-5">
+        <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2">Members</p>
         <MemberList spaceId={space.id} />
       </div>
       {space.image_id && (
@@ -241,11 +241,11 @@ const SpaceDetail: React.FC = () => {
       
       {!showLabelSheet ? (
         <div className="mt-6">
-          <h2 className="text-lg font-semibold mb-2">Boxes</h2>
+          <h2 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3">Boxes</h2>
           {boxes.length === 0 ? (
             <div className="text-muted-foreground">No boxes yet.</div>
           ) : (
-            <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-3">
+            <div className="grid gap-3 grid-cols-2 sm:grid-cols-3 md:grid-cols-4">
               {boxes.map(box => (
                 <BoxCard
                   key={box.id}

--- a/src/pages/Spaces.tsx
+++ b/src/pages/Spaces.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import AppShell from "../components/AppShell";
 import { SpacesSection } from "../components/SpacesSection";
-import { resolveImageUrl, getCachedImageUrl } from "@/lib/imageUrls";
+import { getCachedImageUrl } from "@/lib/imageUrls";
 import { useSpacesStore } from "@/state/spacesStore";
 import { useAuthStore } from "@/state/authStore";
 import { Button } from "@/components/ui/button";
@@ -33,10 +33,8 @@ const Spaces: React.FC = () => {
     ? spaces.filter((s) => s.location === locationFilter)
     : spaces;
 
-  React.useEffect(() => {
-    const ids = filteredSpaces.map(s => s.image_id).filter(Boolean) as string[];
-    ids.forEach(id => resolveImageUrl(id));
-  }, [filteredSpaces]);
+  // Image URLs are resolved lazily by IntersectionObserver inside each SpaceCard.
+  // No eager prefetch here to avoid bursting /api/images/urls for the full list.
 
   const { ownedSpaces, sharedSpaces } = React.useMemo(() => {
     const owned: typeof spaces = [];

--- a/src/pages/Spaces.tsx
+++ b/src/pages/Spaces.tsx
@@ -7,15 +7,7 @@ import { useAuthStore } from "@/state/authStore";
 import { Button } from "@/components/ui/button";
 import { buttonVariants } from "@/components/ui/button-variants";
 import { Spinner } from "@/components/ui/spinner";
-import {
-  Select,
-  SelectTrigger,
-  SelectValue,
-  SelectContent,
-  SelectItem,
-} from "@/components/ui/select";
 import { AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle, AlertDialogDescription, AlertDialogFooter, AlertDialogCancel, AlertDialogAction } from "@/components/ui/alert-dialog";
-
 import { useNavigate } from "react-router-dom";
 
 const Spaces: React.FC = () => {
@@ -31,22 +23,20 @@ const Spaces: React.FC = () => {
   const deletingSpace = spaces.find(s => s.id === deletingId);
   const ALL_LOCATIONS = "__ALL__";
   const [locationFilter, setLocationFilter] = React.useState<string>(ALL_LOCATIONS);
+
   const locations = React.useMemo(() => {
-    const locs = spaces.map(s => s.location).filter((loc): loc is string => typeof loc === 'string' && loc.length > 0);
+    const locs = spaces.map(s => s.location).filter((loc): loc is string => typeof loc === "string" && loc.length > 0);
     return Array.from(new Set(locs)).sort((a, b) => a.localeCompare(b));
   }, [spaces]);
-  const filteredSpaces = locationFilter !== ALL_LOCATIONS
-  ? spaces.filter((s) => s.location === locationFilter)
-  : spaces;
 
-  // Kick off resolution of image URLs for visible spaces (debounced by cache/inflight)
+  const filteredSpaces = locationFilter !== ALL_LOCATIONS
+    ? spaces.filter((s) => s.location === locationFilter)
+    : spaces;
+
   React.useEffect(() => {
     const ids = filteredSpaces.map(s => s.image_id).filter(Boolean) as string[];
     ids.forEach(id => resolveImageUrl(id));
   }, [filteredSpaces]);
-  
-  // Use store loading flag. After loading completes, if there are no spaces show empty state.
-  const isLoading = loading;
 
   const { ownedSpaces, sharedSpaces } = React.useMemo(() => {
     const owned: typeof spaces = [];
@@ -74,90 +64,101 @@ const Spaces: React.FC = () => {
 
   return (
     <AppShell>
-      <h1 className="text-2xl font-bold mb-4">Storage Spaces</h1>
-      <div className="flex items-center gap-4 mb-4">
-        <Button onClick={() => navigate('/spaces/new')} className="w-fit">
+      {/* Header row */}
+      <div className="flex items-center justify-between mb-5">
+        <h1 className="text-xl font-semibold tracking-tight">Spaces</h1>
+        <Button size="sm" onClick={() => navigate("/spaces/new")}>
           + New Space
         </Button>
-        {locations.length > 0 && (
-          <Select value={locationFilter} onValueChange={setLocationFilter}>
-            <SelectTrigger className="w-[180px]">
-              <SelectValue placeholder="All Locations" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value={ALL_LOCATIONS}>All Locations</SelectItem>
-              {locations.map(loc => (
-                <SelectItem key={loc} value={loc}>{loc}</SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        )}
       </div>
-      <div className="flex flex-col gap-6">
-        {isLoading ? (
+
+      {/* Pill location filter */}
+      {locations.length > 0 && (
+        <div className="overflow-x-auto pb-1 -mx-1 px-1 scrollbar-none mb-5">
+          <div className="flex gap-1.5 min-w-max">
+            {[{ value: ALL_LOCATIONS, label: "All" }, ...locations.map(l => ({ value: l, label: l }))].map(({ value, label }) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => setLocationFilter(value)}
+                className={`rounded-full border px-3 py-1 text-xs font-medium whitespace-nowrap transition-colors ${
+                  locationFilter === value
+                    ? "bg-primary text-primary-foreground border-primary"
+                    : "bg-card border-border text-foreground/60 hover:border-primary/40 hover:text-foreground"
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Content */}
+      <div className="flex flex-col gap-8">
+        {loading ? (
           <Spinner size={24} label="Loading spaces..." className="py-8" />
-        ) : Array.isArray(spaces) && spaces.length === 0 ? (
-          <div className="text-muted-foreground py-8">No spaces.</div>
-        ) : Array.isArray(spaces) && filteredSpaces.length === 0 ? (
-          <div className="text-muted-foreground py-8">No spaces match the selected filters.</div>
+        ) : spaces.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-8">No spaces yet. Create your first space to get started.</p>
+        ) : filteredSpaces.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-8">No spaces match this location.</p>
         ) : (
           <>
-      <SpacesSection
-        title="Your Spaces"
-        spaces={ownedSpaces.map(s => ({
-          id: s.id,
-          name: s.name,
-          location: s.location,
-          memberCount: (membershipCounts[s.id] || 0) + 1, // include owner
-          boxCount: s.boxCount,
-          owner: s.owner || undefined,
-          thumbnailUrl: getCachedImageUrl(s.image_id) || undefined,
-          imageId: s.image_id ?? undefined,
-          isShared: false,
-          onOpen: () => navigate(`/spaces/${s.id}`),
-          // Only allow delete if no boxes
-          onDelete: (s.boxCount ?? 0) === 0 ? () => setDeletingId(s.id) : undefined
-        }))}
-      />
-      <SpacesSection
-        title="Shared With You"
-        spaces={sharedSpaces.map(s => ({
-          id: s.id,
-          name: s.name,
-          location: s.location,
-          memberCount: (membershipCounts[s.id] || 0) + (s.owner_id ? 1 : 0),
-          boxCount: s.boxCount,
-          owner: s.owner || undefined,
-          thumbnailUrl: getCachedImageUrl(s.image_id) || undefined,
-          imageId: s.image_id ?? undefined,
-          isShared: true,
-          ownerName: s.owner || undefined,
-          role: membershipRoles[s.id],
-          onOpen: () => navigate(`/spaces/${s.id}`)
-        }))}
-      />
+            <SpacesSection
+              title="Your Spaces"
+              spaces={ownedSpaces.map(s => ({
+                id: s.id,
+                name: s.name,
+                location: s.location,
+                memberCount: (membershipCounts[s.id] || 0) + 1,
+                boxCount: s.boxCount,
+                owner: s.owner || undefined,
+                thumbnailUrl: getCachedImageUrl(s.image_id) || undefined,
+                imageId: s.image_id ?? undefined,
+                isShared: false,
+                onOpen: () => navigate(`/spaces/${s.id}`),
+                onDelete: (s.boxCount ?? 0) === 0 ? () => setDeletingId(s.id) : undefined,
+              }))}
+            />
+            <SpacesSection
+              title="Shared With You"
+              spaces={sharedSpaces.map(s => ({
+                id: s.id,
+                name: s.name,
+                location: s.location,
+                memberCount: (membershipCounts[s.id] || 0) + (s.owner_id ? 1 : 0),
+                boxCount: s.boxCount,
+                owner: s.owner || undefined,
+                thumbnailUrl: getCachedImageUrl(s.image_id) || undefined,
+                imageId: s.image_id ?? undefined,
+                isShared: true,
+                ownerName: s.owner || undefined,
+                role: membershipRoles[s.id],
+                onOpen: () => navigate(`/spaces/${s.id}`),
+              }))}
+            />
           </>
         )}
       </div>
-      {/* Delete dialog mounted once */}
+
       <AlertDialog open={!!deletingId} onOpenChange={open => !open && setDeletingId(null)}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Are you sure?</AlertDialogTitle>
+            <AlertDialogTitle>Delete this space?</AlertDialogTitle>
             <AlertDialogDescription>
-              This action cannot be undone. This will permanently delete the space{" "}
+              This cannot be undone. This will permanently delete{" "}
               <span className="font-semibold">{deletingSpace?.name}</span>.
             </AlertDialogDescription>
           </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel>Cancel</AlertDialogCancel>
-              <AlertDialogAction
-                className={buttonVariants({ variant: "destructive" })}
-                onClick={() => deletingId && handleDelete(deletingId)}
-              >
-                Delete
-              </AlertDialogAction>
-            </AlertDialogFooter>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className={buttonVariants({ variant: "destructive" })}
+              onClick={() => deletingId && handleDelete(deletingId)}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
     </AppShell>

--- a/src/style.css
+++ b/src/style.css
@@ -6,7 +6,6 @@
 /* Add any global styles below */
 
 @theme inline {
-
   --radius-sm: calc(var(--radius) - 4px);
 
   --radius-md: calc(var(--radius) - 2px);
@@ -79,135 +78,52 @@
 }
 
 :root {
+  --radius: 0.75rem;
 
-  --radius: 0.625rem;
+  /* Warm linen palette — hue 68 tilts amber-warm, chroma 0.005-0.014 */
+  --background: oklch(0.971 0.008 68);
+  --foreground: oklch(0.198 0.012 60);
 
-  --background: oklch(1 0 0);
+  --card: oklch(0.991 0.005 68);
+  --card-foreground: oklch(0.198 0.012 60);
 
-  --foreground: oklch(0.145 0 0);
+  --popover: oklch(0.991 0.005 68);
+  --popover-foreground: oklch(0.198 0.012 60);
 
-  --card: oklch(1 0 0);
+  /* Terracotta accent — hue 40, warm orange-red */
+  --primary: oklch(0.592 0.132 40);
+  --primary-foreground: oklch(0.991 0.005 68);
 
-  --card-foreground: oklch(0.145 0 0);
+  --secondary: oklch(0.938 0.012 68);
+  --secondary-foreground: oklch(0.25 0.012 60);
 
-  --popover: oklch(1 0 0);
+  --muted: oklch(0.938 0.012 68);
+  --muted-foreground: oklch(0.555 0.009 65);
 
-  --popover-foreground: oklch(0.145 0 0);
-
-  --primary: oklch(0.205 0 0);
-
-  --primary-foreground: oklch(0.985 0 0);
-
-  --secondary: oklch(0.97 0 0);
-
-  --secondary-foreground: oklch(0.205 0 0);
-
-  --muted: oklch(0.97 0 0);
-
-  --muted-foreground: oklch(0.556 0 0);
-
-  --accent: oklch(0.97 0 0);
-
-  --accent-foreground: oklch(0.205 0 0);
+  --accent: oklch(0.938 0.012 68);
+  --accent-foreground: oklch(0.25 0.012 60);
 
   --destructive: oklch(0.577 0.245 27.325);
 
-  --border: oklch(0.922 0 0);
-
-  --input: oklch(0.922 0 0);
-
-  --ring: oklch(0.708 0 0);
+  --border: oklch(0.875 0.014 68);
+  --input: oklch(0.875 0.014 68);
+  --ring: oklch(0.592 0.132 40);
 
   --chart-1: oklch(0.646 0.222 41.116);
-
   --chart-2: oklch(0.6 0.118 184.704);
-
   --chart-3: oklch(0.398 0.07 227.392);
-
   --chart-4: oklch(0.828 0.189 84.429);
-
   --chart-5: oklch(0.769 0.188 70.08);
 
-  --sidebar: oklch(0.985 0 0);
-
-  --sidebar-foreground: oklch(0.145 0 0);
-
-  --sidebar-primary: oklch(0.205 0 0);
-
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-
-  --sidebar-accent: oklch(0.97 0 0);
-
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-
-  --sidebar-border: oklch(0.922 0 0);
-
-  --sidebar-ring: oklch(0.708 0 0);
-}
-
-.dark {
-
-  --background: oklch(0.145 0 0);
-
-  --foreground: oklch(0.985 0 0);
-
-  --card: oklch(0.205 0 0);
-
-  --card-foreground: oklch(0.985 0 0);
-
-  --popover: oklch(0.205 0 0);
-
-  --popover-foreground: oklch(0.985 0 0);
-
-  --primary: oklch(0.922 0 0);
-
-  --primary-foreground: oklch(0.205 0 0);
-
-  --secondary: oklch(0.269 0 0);
-
-  --secondary-foreground: oklch(0.985 0 0);
-
-  --muted: oklch(0.269 0 0);
-
-  --muted-foreground: oklch(0.708 0 0);
-
-  --accent: oklch(0.269 0 0);
-
-  --accent-foreground: oklch(0.985 0 0);
-
-  --destructive: oklch(0.704 0.191 22.216);
-
-  --border: oklch(1 0 0 / 10%);
-
-  --input: oklch(1 0 0 / 15%);
-
-  --ring: oklch(0.556 0 0);
-
-  --chart-1: oklch(0.488 0.243 264.376);
-
-  --chart-2: oklch(0.696 0.17 162.48);
-
-  --chart-3: oklch(0.769 0.188 70.08);
-
-  --chart-4: oklch(0.627 0.265 303.9);
-
-  --chart-5: oklch(0.645 0.246 16.439);
-
-  --sidebar: oklch(0.205 0 0);
-
-  --sidebar-foreground: oklch(0.985 0 0);
-
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-
-  --sidebar-accent: oklch(0.269 0 0);
-
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-
-  --sidebar-border: oklch(1 0 0 / 10%);
-
-  --sidebar-ring: oklch(0.556 0 0);
+  /* Sidebar: slightly warmer cream */
+  --sidebar: oklch(0.962 0.01 68);
+  --sidebar-foreground: oklch(0.198 0.012 60);
+  --sidebar-primary: oklch(0.592 0.132 40);
+  --sidebar-primary-foreground: oklch(0.991 0.005 68);
+  --sidebar-accent: oklch(0.938 0.012 68);
+  --sidebar-accent-foreground: oklch(0.25 0.012 60);
+  --sidebar-border: oklch(0.875 0.014 68);
+  --sidebar-ring: oklch(0.592 0.132 40);
 }
 
 @layer base {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,16 @@ import path from "path";
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  server: {
+    proxy: {
+      // Proxy Azure Functions API calls to the local Functions runtime.
+      // Run: cd api && func start  (or use: swa start)
+      "/api": {
+        target: "http://localhost:7071",
+        changeOrigin: true,
+      },
+    },
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## Summary

A complete UX redesign with warm linen/terracotta palette, plus fixes for image loading and blurriness.

---

### UX Redesign (`feat: warm UX redesign`)

- **Design tokens** — warm OKLCH palette in `src/style.css`: linen background, cream sidebar, terracotta primary, warm sand borders
- **AppShell** — rebuilt with warm top bar, `w-52` cream sidebar, mobile bottom tab bar (Spaces + Profile only)
- **SpaceCard / BoxCard** — image-top card layout with `aspect-[4/3]` / `aspect-[3/2]`, IntersectionObserver lazy loading, hover delete button, shared badge overlay
- **SpacesSection** — responsive `grid-cols-2 sm:grid-cols-3 lg:grid-cols-4` card grid
- **Spaces page** — pill location filter replaces dropdown
- **Auth page** — warm card, outline provider buttons
- **Profile page** — identity card, AlertDialog-confirmed sign-out
- **SpaceDetail / BoxDetail** — tighter spacing, denser box grid

### Bug Fixes

| Commit | Fix |
|---|---|
| `f121978` | Supabase `RejectExcessProperties` TS errors in `useEntityUpdate` — cast to `Partial<Omit<Space, "boxCount">>` and `Partial<Box>` |
| `7296697` | Vite dev proxy for `/api/*` → `localhost:7071` so image URLs resolve during local development |
| `23566d2` | Thumbnail resolution increased from 150×150px to 480×360px (4:3) — prevents blur in card grids |
| `98c4df1` | Admin function `POST /api/admin/regenerate-thumbnails` to retroactively fix existing blurry thumbnails without requiring re-upload |

### Running the thumbnail migration

After deploying, set `ADMIN_KEY` in Function App settings and trigger once:

```bash
curl -X POST https://{host}/api/admin/regenerate-thumbnails \
     -H "X-Admin-Key: {ADMIN_KEY}"
```
