### PR TITLE
ci: add workflow_dispatch to allow manual deployments

### DIFF
--- a/.github/workflows/azure-static-web-apps-salmon-water-0cd0de103.yml
+++ b/.github/workflows/azure-static-web-apps-salmon-water-0cd0de103.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build_and_deploy_job:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:

--- a/.github/workflows/azure-static-web-apps-salmon-water-0cd0de103.yml
+++ b/.github/workflows/azure-static-web-apps-salmon-water-0cd0de103.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches:


### PR DESCRIPTION
Adds `workflow_dispatch` to the CI/CD workflow so deployments can be triggered manually from the GitHub Actions UI without needing to push an empty commit.