### PR TITLE
fix: scrollable Edit Space dialog + scroll to new image on upload

### DIFF
--- a/src/__tests__/integration/imageUploadScroll.test.tsx
+++ b/src/__tests__/integration/imageUploadScroll.test.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import EditSpaceModal from "@/components/EditSpaceModal";
+import type { Space } from "@/types/entities";
+
+// Mock imageUrls so that edit modals and MultiImageUploadField can resolve previews
+vi.mock("@/lib/imageUrls", () => ({
+  resolveImageUrl: vi.fn().mockResolvedValue("https://cdn/existing.jpg"),
+  getCachedImageUrl: vi.fn().mockReturnValue(undefined),
+  prefetchImageUrls: vi.fn().mockResolvedValue({}),
+}));
+
+// Mock uploadImage/confirmImages so uploads resolve without hitting the network
+vi.mock("@/lib/imageUpload", () => ({
+  uploadImage: vi
+    .fn()
+    .mockResolvedValueOnce({ imageId: "new1", previewUrl: "https://cdn/new1.jpg" })
+    .mockResolvedValueOnce({ imageId: "new2", previewUrl: "https://cdn/new2.jpg" }),
+  confirmImages: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/hooks/useEntityUpdate", () => ({
+  useEntityUpdate: () => ({ mutate: vi.fn(), loading: false }),
+}));
+
+vi.mock("@/supabaseClient", () => ({
+  supabase: {
+    from: () => ({ update: () => ({ eq: () => ({ error: null }) }) }),
+    auth: { onAuthStateChange: () => ({ data: { subscription: { unsubscribe: () => {} } } }) },
+  },
+}));
+
+vi.mock("@/components/ui/alert-dialog", () => {
+  const W: React.FC<React.PropsWithChildren> = ({ children }) => <div>{children}</div>;
+  return {
+    AlertDialog: W,
+    AlertDialogContent: W,
+    AlertDialogHeader: W,
+    AlertDialogTitle: W,
+    AlertDialogFooter: W,
+    AlertDialogDescription: W,
+  };
+});
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, type = "button", ...rest }: React.PropsWithChildren<{ type?: "button" | "submit" | "reset"; disabled?: boolean; onClick?: () => void }>) => (
+    <button type={type} {...rest}>{children}</button>
+  ),
+}));
+vi.mock("@/components/ui/input", () => ({
+  Input: React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
+    (props, ref) => <input ref={ref} {...props} />,
+  ),
+}));
+vi.mock("sonner", () => ({ toast: { success: () => {}, error: () => {} } }));
+
+describe("scroll to newly uploaded image", () => {
+  const scrollIntoViewSpy = vi.fn();
+
+  beforeEach(() => {
+    scrollIntoViewSpy.mockClear();
+    HTMLElement.prototype.scrollIntoView = scrollIntoViewSpy;
+  });
+
+  it("scrolls to the first newly added image after an upload, not an existing one", async () => {
+    const space: Space = {
+      id: "space1",
+      name: "My Space",
+      owner_id: "u1",
+      image_id: "existing1",
+      image_ids: ["existing1"],
+      location: "Shelf",
+    };
+    render(<EditSpaceModal open={true} onClose={() => {}} space={space} />);
+
+    const fileInput = document.getElementById("image_ids-input") as HTMLInputElement;
+    const files = [
+      new File(["a"], "a.png", { type: "image/png" }),
+      new File(["b"], "b.png", { type: "image/png" }),
+    ];
+    Object.defineProperty(fileInput, "files", { value: files });
+    fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+
+    await waitFor(() => expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1));
+
+    // Order is deterministic: existing1 (index 0), new1 (index 1), new2 (index 2).
+    // The first newly uploaded image, new1, should be the one scrolled into view.
+    const grid = document.querySelector(".grid.gap-3") as HTMLElement;
+    const scrolledEl = scrollIntoViewSpy.mock.contexts[0] as HTMLElement;
+    expect(scrolledEl).toBe(grid.children[1]);
+  });
+});

--- a/src/components/EditSpaceModal.tsx
+++ b/src/components/EditSpaceModal.tsx
@@ -46,13 +46,13 @@ const EditSpaceModal: React.FC<EditSpaceModalProps> = ({ open, onClose, space })
 
   return (
     <AlertDialog open={open} onOpenChange={onClose}>
-      <AlertDialogContent>
+      <AlertDialogContent className="max-h-[90svh] sm:max-h-[85vh] overflow-hidden flex flex-col">
         <AlertDialogHeader>
           <AlertDialogTitle>Edit Space</AlertDialogTitle>
           <AlertDialogDescription />
         </AlertDialogHeader>
         <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4 overflow-y-auto pr-1 -mr-1 flex-1">
             <FormField name="name" render={({ field }) => (
               <FormItem>
                 <FormLabel>Name</FormLabel>
@@ -88,7 +88,7 @@ const EditSpaceModal: React.FC<EditSpaceModalProps> = ({ open, onClose, space })
                 }}
               />
             </FormItem>
-            <AlertDialogFooter>
+            <AlertDialogFooter className="sticky bottom-0 bg-background pt-2">
               <Button
                 type="submit"
                 disabled={loading || imageUploading}

--- a/src/components/forms/MultiImageUploadField.tsx
+++ b/src/components/forms/MultiImageUploadField.tsx
@@ -30,6 +30,8 @@ export const MultiImageUploadField: React.FC<MultiImageUploadFieldProps> = ({
 }) => {
     const { setValue, watch } = useFormContext();
     const inputRef = React.useRef<HTMLInputElement | null>(null);
+    const itemRefs = React.useRef<Map<string, HTMLDivElement>>(new Map());
+    const [pendingScrollId, setPendingScrollId] = React.useState<string | null>(null);
     const imageIds = ((watch(name) as string[] | undefined) ?? []).filter(
         (id): id is string => typeof id === "string" && id.length > 0,
     );
@@ -72,6 +74,15 @@ export const MultiImageUploadField: React.FC<MultiImageUploadFieldProps> = ({
         };
     }, [imageIdsKey]);
 
+    React.useEffect(() => {
+        if (!pendingScrollId) return;
+        const el = itemRefs.current.get(pendingScrollId);
+        if (el) {
+            el.scrollIntoView({ behavior: "smooth", block: "nearest" });
+            setPendingScrollId(null);
+        }
+    }, [pendingScrollId, imageIdsKey]);
+
     const setImages = React.useCallback(
         (nextIds: string[]) => {
             setValue(name as any, nextIds as any, { shouldDirty: true, shouldTouch: true }); // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -104,6 +115,9 @@ export const MultiImageUploadField: React.FC<MultiImageUploadFieldProps> = ({
                 new Set([...imageIds, ...uploads.map((result) => result.imageId)]),
             );
             setImages(nextIds);
+            if (uploads.length > 0) {
+                setPendingScrollId(uploads[0].imageId);
+            }
             await onImagesUploaded?.(uploads);
         } catch (err) {
             setError((err as Error).message || "Upload failed");
@@ -192,7 +206,11 @@ export const MultiImageUploadField: React.FC<MultiImageUploadFieldProps> = ({
                         return (
                             <div
                                 key={imageId}
-                                className="rounded-xl border border-border bg-card p-2 space-y-2"
+                                ref={(el) => {
+                                    if (el) itemRefs.current.set(imageId, el);
+                                    else itemRefs.current.delete(imageId);
+                                }}
+                                className="rounded-xl border border-border bg-card p-2 space-y-2 scroll-mt-2 scroll-mb-16"
                             >
                                 <div className="relative overflow-hidden rounded-lg bg-muted aspect-[4/3]">
                                     {src ? (


### PR DESCRIPTION
## Summary
- `EditSpaceModal`'s `AlertDialogContent` had no max-height/overflow handling, so on short mobile viewports (e.g. iPhone 12) uploading a second image could make the dialog taller than the screen with no way to scroll to reach the Save button. Applies the same constrained-height/internal-scroll/sticky-footer pattern already used by `EditBoxModal`/`CreateBoxModal` (was apparently missed when multi-image support landed in #30).
- Follow-up UX improvement: after uploading one or more images, the dialog now auto-scrolls to the first newly added image tile, so users landing below the fold immediately see what they just added instead of having to hunt for it. This lives in the shared `MultiImageUploadField`, so it applies to both space and box editing.

## Test plan
- [x] `npm run lint`
- [x] `npm run test` (24/24 passing, includes new `imageUploadScroll.test.tsx`)
- [x] `npm run build`
- [x] Manual check on iPhone 12 / short viewport after deploy — reported by user, not independently reproduced in this session (no test account available here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)