### PR TITLE
chore: upgrade lucide-react to 1.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@tailwindcss/vite": "^4.2.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "lucide-react": "^0.544.0",
+        "lucide-react": "^1.24.0",
         "next-themes": "^0.4.6",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -4972,9 +4972,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.544.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.544.0.tgz",
-      "integrity": "sha512-t5tS44bqd825zAW45UQxpG2CvcC4urOwn2TrwSH8u+MjeE+1NnWl6QqeQ/6NdjMqdOygyiT9p3Ev0p1NJykxjw==",
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.24.0.tgz",
+      "integrity": "sha512-YT6mBD8lGKkg4nM39enlm94/sfJIiW0YKUT60fBy4YK8tai31ylg1VhGNWxkpSKHo9UagfnZqwIff3HTDQwXeA==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@tailwindcss/vite": "^4.2.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "lucide-react": "^0.544.0",
+    "lucide-react": "^1.24.0",
     "next-themes": "^0.4.6",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",


### PR DESCRIPTION
## Summary
- Upgrades `lucide-react` from ^0.544.0 to ^1.24.0 (its first stable major release).
- Only two files import from lucide-react: `src/components/ui/select.tsx` (`CheckIcon`, `ChevronDownIcon`, `ChevronUpIcon`) and `src/components/ui/sheet.tsx` (`XIcon`) — all four exports still exist and resolve correctly in 1.x.
- Checked the official v1 migration notes: the only breaking changes are removal of trademark/brand icons (none used here), `aria-hidden` now defaulting to `true`, dropping the UMD build (this project is ESM-only via Vite), and a Vue package rename (not applicable). None affect this codebase.

## Test plan
- [x] `npm run lint`
- [x] `npm run test` (24/24 passing)
- [x] `npm run build`

No source changes beyond `package.json`/`package-lock.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)