### PR TITLE
chore: bump SixLabors.ImageSharp to 3.1.12 (license-free patch)

### DIFF
--- a/api/api.csproj
+++ b/api/api.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.51.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Bumps `SixLabors.ImageSharp` 3.1.11 → 3.1.12 in `api/api.csproj`. This is the latest version on the 3.x line, which remains license-free.
- ImageSharp 4.0.0 was investigated first but rejected for now: Six Labors added hard license-key enforcement at build time starting in v4 (`dotnet build` refuses to compile without `SixLaborsLicenseKey`/a `.lic` file). That's a licensing/business decision, not a code change, so it's being deferred separately. The actual API surface used in `RegenerateThumbnails.cs` (`Image.LoadAsync`, `Clone`/`Resize`, `WebpEncoder`, `SaveAsync`) was confirmed identical between 3.1.11 and 4.0.0, so this patch bump needed no code changes and the future v4 move (once/if licensing is sorted) should be a clean drop-in.

## Test plan
- [x] `dotnet build` — succeeds, 0 warnings/errors
- [x] `dotnet list package --vulnerable` — none

🤖 Generated with [Claude Code](https://claude.com/claude-code)