### PR TITLE
chore: remove unused Playwright dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ dist-ssr
 *.sw?
 .agents/
 .github/skills/impeccable
+.claude/

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,6 @@
         "eslint-plugin-react-refresh": "^0.4.26",
         "globals": "^16.5.0",
         "jsdom": "^29.1.1",
-        "playwright": "^1.58.2",
         "supabase": "^2.109.1",
         "tw-animate-css": "^1.4.0",
         "typescript": "^5.9.3",
@@ -3390,21 +3389,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -4229,38 +4213,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/playwright": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
-      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright-core": "1.61.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/playwright-core": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
-      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "eslint-plugin-react-refresh": "^0.4.26",
     "globals": "^16.5.0",
     "jsdom": "^29.1.1",
-    "playwright": "^1.58.2",
     "supabase": "^2.109.1",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5.9.3",


### PR DESCRIPTION
## Summary
- Removes `playwright` from `package.json`/`package-lock.json`. Confirmed via a repo-wide search: no `playwright.config.ts`, no e2e test directory, no CI references anywhere — it was an unused dependency.
- Also adds `.claude/` to `.gitignore`: git worktrees created there during this session's parallel dependency-upgrade work weren't excluded, so `eslint .` was recursing into their nested `node_modules`/configs and crashing on stale content from an unrelated branch. Unrelated to Playwright but trivial, bundled in rather than opening a separate PR for one line.

## Test plan
- [x] `npm run lint`
- [x] `npm run test` (24/24 passing)
- [x] `npm run build`

If E2E testing is wanted later, Playwright (or another tool) can be re-added deliberately alongside actual tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)