### PR TITLE
chore: add Dependabot config for npm, NuGet, and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  # Routine minor/patch bumps are grouped into one low-risk PR per week.
+  # Major version bumps are deliberately left ungrouped - each gets its
+  # own PR, since those are the ones that tend to need real scrutiny
+  # (breaking config changes, license changes, etc.), not a blanket merge.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      npm-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "nuget"
+    directory: "/api"
+    schedule:
+      interval: "weekly"
+    groups:
+      nuget-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` with weekly checks across all three ecosystems in this repo: npm (root), NuGet (`api/`), and GitHub Actions (root).
- Minor/patch bumps are grouped into a single low-risk PR per ecosystem per week. Major version bumps are **deliberately left ungrouped** so each gets its own individual PR — this session found real breaking changes hiding behind several "routine" major bumps (Vite 8's bundler swap requiring a config rewrite, ESLint 10's plugin config format change, ImageSharp 4's new license-key enforcement, App Insights WorkerService 3's runtime-crashing binary incompatibility). Grouping those together would have hidden exactly the kind of thing that needs individual review.

## Test plan
- [x] Validated YAML syntax
- [ ] First scheduled Dependabot run (can't be tested locally — will confirm once it runs against the repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)