### PR TITLE
chore: upgrade globals to ^17.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "eslint": "^10.7.0",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.3",
-        "globals": "^16.5.0",
+        "globals": "^17.7.0",
         "jsdom": "^29.1.1",
         "supabase": "^2.109.1",
         "tw-animate-css": "^1.4.0",
@@ -3422,9 +3422,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
-      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "eslint": "^10.7.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.3",
-    "globals": "^16.5.0",
+    "globals": "^17.7.0",
     "jsdom": "^29.1.1",
     "supabase": "^2.109.1",
     "tw-animate-css": "^1.4.0",


### PR DESCRIPTION
## Summary
Bumps the `globals` devDependency 16.5.0 → 17.7.0. Replaces closed #47 (the original Dependabot PR), which hit a lockfile conflict against `main` after #43/#45 merged — redone as a normal PR instead of pushing conflict-resolution commits onto the Dependabot-owned branch.

## Test plan
- [x] `npm run lint`
- [x] `npm run test` (24/24 passing)
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)