### PR TITLE
Pin desktop sidebar nav to the left

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -55,7 +55,7 @@ const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) => {
       {/* Layout body */}
       <div className="flex flex-1">
         {/* Desktop sidebar */}
-        <aside className="hidden md:flex md:flex-col md:w-52 md:shrink-0 bg-sidebar border-r border-sidebar-border">
+        <aside className="hidden md:flex md:flex-col md:w-52 md:shrink-0 md:fixed md:top-14 md:left-0 md:bottom-0 md:z-30 bg-sidebar border-r border-sidebar-border md:overflow-y-auto">
           <nav className="p-3 flex flex-col gap-0.5" aria-label="Main navigation">
             {navLinks.map((link) => {
               const active = isActive(link.href);
@@ -78,7 +78,7 @@ const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) => {
         </aside>
 
         {/* Main content */}
-        <main className="flex-1 min-w-0 pb-20 md:pb-0">
+        <main className="flex-1 min-w-0 pb-20 md:pb-0 md:ml-52">
           <div className="max-w-4xl mx-auto px-4 py-6">{children}</div>
         </main>
       </div>


### PR DESCRIPTION
## Summary
- The desktop sidebar nav in `AppShell` was a normal flow element inside the layout's flex row, so it scrolled away with page content (e.g. scrolling through a long list of boxes in a space).
- It's now `fixed` to the left, below the sticky header, so it stays pinned while the main content scrolls — matching the mobile bottom nav, which was already fixed.
- Main content gets a matching `md:ml-52` offset so it isn't hidden behind the now-fixed sidebar.

## Test plan
- [x] `npm run lint` passes
- [x] Verified with Playwright against the dev server: injected tall content on `/spaces`, scrolled 1500px, confirmed the sidebar's bounding box (position, size) is unchanged and its computed CSS `position` is `fixed`
- [x] Confirmed mobile viewport (390x844) still shows the bottom nav pinned as before, with no desktop sidebar rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)